### PR TITLE
Add run-export on itself

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,8 +6,8 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://webkitgtk.org/releases/webkitgtk-${{ version }}.tar.xz
-  sha256: f62c1077d3a0f63d50259a802d1143be5d4d0c7c4c05e581819af1ce935afab3
+  git: https://github.com/WebKit/WebKit.git
+  tag: "webkitgtk-${{ version }}"
 
 build:
   number: 2

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f62c1077d3a0f63d50259a802d1143be5d4d0c7c4c05e581819af1ce935afab3
 
 build:
-  number: 1
+  number: 2
   skip: not linux
   script:
     - |
@@ -75,6 +75,8 @@ requirements:
     - xdg-dbus-proxy
     - xorg-xorgproto
     - zlib
+  run_exports:
+    - ${{ pin_subpackage('webkit2gtk4.1', exact=True) }}
 
 tests:
   - package_contents:


### PR DESCRIPTION
Since webkit2gtk4.1  provides a shared library it needs to have a run export on itself so that the shared library is then also available during runtime

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
